### PR TITLE
Change open encoding to utf16

### DIFF
--- a/parsers/peas2json.py
+++ b/parsers/peas2json.py
@@ -145,7 +145,7 @@ def parse_line(line: str):
 
 
 def main():
-    for line in open(OUTPUT_PATH, 'r', encoding="utf8").readlines():
+    for line in open(OUTPUT_PATH, 'r', encoding="utf16").readlines():
         line = line.strip()
         if not line or not clean_colors(line): #Remove empty lines or lines just with colors hex
             continue


### PR DESCRIPTION
When trying to use file from winPEAS it failed to parse it to json using `peas2json.py` because of:

```bash
Traceback (most recent call last):
  File "/peas2json.py", line 168, in <module>
    main()
    ~~~~^^
  File "/peas2json.py", line 148, in main
    for line in open(OUTPUT_PATH, 'r', encoding="utf8").readlines():
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "<frozen codecs>", line 325, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```

With `utf16` encoding, there is no such problem